### PR TITLE
HC-137: docker stats

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,7 +59,10 @@ RUN set -ex \
 USER $USER
 WORKDIR /home/$USER
 
-# set entrypoint
+# copy entrypoints
 COPY docker/docker-entrypoint.sh /docker-entrypoint.sh
+COPY docker/docker-entrypoint-with-stats.sh /docker-entrypoint-with-stats.sh
+
+# set default entrypoint
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["/bin/bash", "--login"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,9 @@ LABEL description "Base HySDS image"
 # Set gosu version
 ENV GOSU_VERSION 1.10
 
+# Set docker-stats-on-exit-shim version
+ENV DSOES_VERSION v1.0
+
 # Set user and group
 ENV USER ops
 ENV GROUP ops
@@ -47,7 +50,10 @@ RUN set -ex \
  && rm /usr/local/bin/gosu.asc \
  && rm -r /root/.gnupg/ \
  && chmod +x /usr/local/bin/gosu \
- && chmod u+s /usr/local/bin/gosu
+ && chmod u+s /usr/local/bin/gosu \
+ && curl -o /docker-stats-on-exit-shim -SL "https://github.com/hysds/docker-stats-on-exit-shim/releases/download/${DSOES_VERSION}/docker-stats-on-exit-shim" \
+ && chmod +x /docker-stats-on-exit-shim \
+ && chmod u+s /docker-stats-on-exit-shim
 
 # set default user and workdir
 USER $USER

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -59,7 +59,10 @@ RUN set -ex \
 USER $USER
 WORKDIR /home/$USER
 
-# set entrypoint
+# copy entrypoints
 COPY docker/docker-entrypoint.sh /docker-entrypoint.sh
+COPY docker/docker-entrypoint-with-stats.sh /docker-entrypoint-with-stats.sh
+
+# set default entrypoint
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["/bin/bash", "--login"]

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -6,6 +6,9 @@ LABEL description "CUDA Base HySDS image"
 # Set gosu version
 ENV GOSU_VERSION 1.10
 
+# Set docker-stats-on-exit-shim version
+ENV DSOES_VERSION v1.0
+
 # Set user and group
 ENV USER ops
 ENV GROUP ops
@@ -47,7 +50,10 @@ RUN set -ex \
  && rm /usr/local/bin/gosu.asc \
  && rm -r /root/.gnupg/ \
  && chmod +x /usr/local/bin/gosu \
- && chmod u+s /usr/local/bin/gosu
+ && chmod u+s /usr/local/bin/gosu \
+ && curl -o /docker-stats-on-exit-shim -SL "https://github.com/hysds/docker-stats-on-exit-shim/releases/download/${DSOES_VERSION}/docker-stats-on-exit-shim" \
+ && chmod +x /docker-stats-on-exit-shim \
+ && chmod u+s /docker-stats-on-exit-shim
 
 # set default user and workdir
 USER $USER

--- a/docker/docker-entrypoint-with-stats.sh
+++ b/docker/docker-entrypoint-with-stats.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+# set HOME explicitly
+export HOME=/home/ops
+
+# get group id
+GID=$(id -g)
+
+# update user and group ids
+gosu 0:0 groupmod -g $GID ops 2>/dev/null
+gosu 0:0 usermod -u $UID -g $GID ops 2>/dev/null
+gosu 0:0 usermod -aG docker ops 2>/dev/null
+
+# update ownership
+gosu 0:0 chown -R $UID:$GID $HOME 2>/dev/null || true
+gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
+
+# source bash profile
+source $HOME/.bash_profile
+
+exec gosu $UID:$GID /docker-stats-on-exit-shim _docker_stats.json "$@"


### PR DESCRIPTION
This PR installs a prebuilt shim, `docker-stats-on-exit`, that allows developers to utilize it for dumping out a container's resource usage prior to exiting.