### PR TITLE
HC-385: pin python3.8 installer

### DIFF
--- a/manifests/anaconda.pp
+++ b/manifests/anaconda.pp
@@ -11,7 +11,9 @@ define hysds_base::anaconda($path='/opt/conda', $action=install_miniconda, $args
 
       exec { "download_installer":
         path    => "/usr/local/bin:/usr/bin:/bin",
-        command => "curl -sSL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh",
+        # TODO: undo this pin once https://hysds-core.atlassian.net/browse/HC-385 is resolved
+        #command => "curl -sSL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh",
+        command => "curl -sSL https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-x86_64.sh -o /tmp/miniconda.sh",
         creates => "/tmp/miniconda.sh", 
       }
 


### PR DESCRIPTION
As a stopgap measure until we can vet HySDS core on python 3.9, this PR pins the Miniconda installer to python3.8.