### PR TITLE
NSDS-1951: Refactor to auto build oraclelinux and centos7 docker images

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -10,7 +10,7 @@ ORG=$2
 BRANCH=$3
 
 # build base images
-docker build --rm --force-rm --build-arg ORG=${ORG} --build-arg BRANCH=${BRANCH} \
+docker build --rm --force-rm --progress=plain --build-arg ORG=${ORG} --build-arg BRANCH=${BRANCH} \
   -t hysds/base:${TAG} -f docker/Dockerfile .
-docker build --rm --force-rm --build-arg ORG=${ORG} --build-arg BRANCH=${BRANCH} \
-  -t hysds/cuda-base:${TAG} -f docker/Dockerfile.cuda .
+docker build --rm --force-rm --progress=plain --build-arg TAG=${TAG} --build-arg ORG=${ORG} \
+  --build-arg BRANCH=${BRANCH} -t hysds/cuda-base:${TAG} -f docker/Dockerfile.cuda .

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -24,6 +24,8 @@ ENV GIT_URL https://github.com/${ORG}/puppet-hysds_base/raw/${BRANCH}/install.sh
 # add latest repo version to invalidate cache
 ADD https://api.github.com/repos/${ORG}/puppet-hysds_base/git/refs/heads/${BRANCH} version.json
 
+USER root
+
 # provision via puppet
 RUN set -ex \
  && yum install -y epel-release \

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,4 +1,5 @@
-FROM nvidia/cuda:11.4.1-runtime-centos7
+ARG TAG=develop
+FROM hysds/base:${TAG}
 
 MAINTAINER Gerald Manipon (pymonger) "pymonger@gmail.com"
 LABEL description "CUDA Base HySDS image"

--- a/install.sh
+++ b/install.sh
@@ -71,7 +71,7 @@ site_pp=$mod_dir/site.pp
 
 # check that module is here; if not, export it
 if [ ! -d $mod_dir ]; then
-  $git_cmd clone --single-branch -b $BRANCH $git_loc $mod_dir
+  $git_cmd clone --single-branch -b $BRANCH $git_loc $mod_dir --depth 1
 fi
 
 


### PR DESCRIPTION
Refactored to allow HySDS release creation to build docker images built on oraclelinux:8 and centos:7.

```
(base) MT-204713:swot-pcm mcayanan$ docker images | grep "hysds/base"
hysds/base            20220224          84bfbe2ffabb   5 days ago     2.76GB
hysds/base            develop-centos7   84bfbe2ffabb   5 days ago     2.76GB
hysds/base            develop           e5a98c2c044d   7 days ago     3.05GB
(base) MT-204713:swot-pcm mcayanan$ docker images | grep "hysds/cuda-base"
hysds/cuda-base       20220301          58fe598fbe94   3 hours ago    2.79GB
hysds/cuda-base       develop-centos7   58fe598fbe94   3 hours ago    2.79GB
```

```
(base) MT-204713:swot-pcm mcayanan$ docker run -it hysds/base:develop-centos7 /bin/bash
ops@0080ef1c0b4f:~$ more /etc/redhat-release 
CentOS Linux release 7.9.2009 (Core)
ops@0080ef1c0b4f:~$ exit
exit
(base) MT-204713:swot-pcm mcayanan$ docker run -it hysds/cuda-base:develop-centos7 /bin/bash
ops@35d4d6ae768e:~$ more /etc/redhat-release 
CentOS Linux release 7.9.2009 (Core)
ops@35d4d6ae768e:~$ 
```

