### PR TITLE
hot-fix: Update Cuda Public Repo Signing Key

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -33,7 +33,7 @@ COPY files/cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
 USER root
 
 RUN NVIDIA_GPGKEY_SUM=d1be581509378368edeec8c1eb2958702feedf3bc3d17011adbf24efacce4ab5 && \
-    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${NVARCH}/7fa2af80.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
+    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${NVARCH}/3bf863cc.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
     echo "$NVIDIA_GPGKEY_SUM  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA" | sha256sum -c --strict -
 
 ENV CUDA_VERSION 11.4.2


### PR DESCRIPTION
The current CircleCI build fails to build the Cuda Base image. It fails with the following error:

```
Importing GPG key 0x7FA2AF80:
 Userid     : "cudatools <cudatools@nvidia.com>"
 Fingerprint: AE09 FE4B BD22 3A84 B2CC FCE3 F60F 4B3D 7FA2 AF80
 From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
Key imported successfully
Import of key(s) didn't help, wrong key(s)?
Public key for cuda-compat-11-4-470.129.06-1.x86_64.rpm is not installed. Failing package is: cuda-compat-11-4-1:470.129.06-1.x86_64
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
Public key for cuda-cudart-11-4-11.4.108-1.x86_64.rpm is not installed. Failing package is: cuda-cudart-11-4-11.4.108-1.x86_64
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
Public key for cuda-toolkit-11-4-config-common-11.4.148-1.noarch.rpm is not installed. Failing package is: cuda-toolkit-11-4-config-common-11.4.148-1.noarch
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
Public key for cuda-toolkit-11-config-common-11.7.60-1.noarch.rpm is not installed. Failing package is: cuda-toolkit-11-config-common-11.7.60-1.noarch
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
Public key for cuda-toolkit-config-common-11.7.60-1.noarch.rpm is not installed. Failing package is: cuda-toolkit-config-common-11.7.60-1.noarch
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
The downloaded packages were saved in cache until the next successful transaction.
You can remove cached packages by executing 'dnf clean packages'.
Error: GPG check FAILED
```
According to https://hub.docker.com/r/nvidia/cuda, the Cuda signing key has changed.

In looking at https://gitlab.com/nvidia/container-images/cuda/-/issues/158, the resolution is to update the Cuda Public Repo Signing Key.