### PR TITLE
hot-fix: Update Cuda Public Signing Key

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -32,11 +32,11 @@ COPY files/cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
 
 USER root
 
-#RUN curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${NVARCH}/3bf863cc.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
-#RUN more /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
+RUN curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
+RUN more /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
 
 RUN NVIDIA_GPGKEY_SUM=d1be581509378368edeec8c1eb2958702feedf3bc3d17011adbf24efacce4ab5 && \
-    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${NVARCH}/7fa2af80.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
+    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
     echo "$NVIDIA_GPGKEY_SUM  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA" | sha256sum -c --strict -
 
 ENV CUDA_VERSION 11.4.2

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -33,7 +33,7 @@ COPY files/cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
 USER root
 
 RUN NVIDIA_GPGKEY_SUM=d1be581509378368edeec8c1eb2958702feedf3bc3d17011adbf24efacce4ab5 && \
-    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${NVARCH}/7fa2af80.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
+    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${NVARCH}/3bf863cc.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
     echo "$NVIDIA_GPGKEY_SUM  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA" | sha256sum -c --strict -
 
 ENV CUDA_VERSION 11.4.2

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -32,10 +32,10 @@ COPY files/cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
 
 USER root
 
-RUN curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
-RUN more /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
+#RUN curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
+#RUN more /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
 
-RUN NVIDIA_GPGKEY_SUM=d1be581509378368edeec8c1eb2958702feedf3bc3d17011adbf24efacce4ab5 && \
+RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3b80c8 && \
     curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
     echo "$NVIDIA_GPGKEY_SUM  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA" | sha256sum -c --strict -
 

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -32,8 +32,11 @@ COPY files/cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
 
 USER root
 
+#RUN curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${NVARCH}/3bf863cc.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
+#RUN more /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
+
 RUN NVIDIA_GPGKEY_SUM=d1be581509378368edeec8c1eb2958702feedf3bc3d17011adbf24efacce4ab5 && \
-    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${NVARCH}/3bf863cc.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
+    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${NVARCH}/7fa2af80.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
     echo "$NVIDIA_GPGKEY_SUM  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA" | sha256sum -c --strict -
 
 ENV CUDA_VERSION 11.4.2

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -32,9 +32,6 @@ COPY files/cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
 
 USER root
 
-#RUN curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
-#RUN more /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
-
 RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3b80c8 && \
     curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
     echo "$NVIDIA_GPGKEY_SUM  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA" | sha256sum -c --strict -

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -32,7 +32,7 @@ COPY files/cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
 
 USER root
 
-RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3b80c8 && \
+RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3b80c87 && \
     curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
     echo "$NVIDIA_GPGKEY_SUM  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA" | sha256sum -c --strict -
 


### PR DESCRIPTION
The current CircleCI build fails to build the Cuda Base image. It fails with the following error:

```
Importing GPG key 0x7FA2AF80:
 Userid     : "cudatools <cudatools@nvidia.com>"
 Fingerprint: AE09 FE4B BD22 3A84 B2CC FCE3 F60F 4B3D 7FA2 AF80
 From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
Key imported successfully
Import of key(s) didn't help, wrong key(s)?
Public key for cuda-compat-11-4-470.129.06-1.x86_64.rpm is not installed. Failing package is: cuda-compat-11-4-1:470.129.06-1.x86_64
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
Public key for cuda-cudart-11-4-11.4.108-1.x86_64.rpm is not installed. Failing package is: cuda-cudart-11-4-11.4.108-1.x86_64
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
Public key for cuda-toolkit-11-4-config-common-11.4.148-1.noarch.rpm is not installed. Failing package is: cuda-toolkit-11-4-config-common-11.4.148-1.noarch
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
Public key for cuda-toolkit-11-config-common-11.7.60-1.noarch.rpm is not installed. Failing package is: cuda-toolkit-11-config-common-11.7.60-1.noarch
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
Public key for cuda-toolkit-config-common-11.7.60-1.noarch.rpm is not installed. Failing package is: cuda-toolkit-config-common-11.7.60-1.noarch
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
The downloaded packages were saved in cache until the next successful transaction.
You can remove cached packages by executing 'dnf clean packages'.
Error: GPG check FAILED
```

According to https://hub.docker.com/r/nvidia/cuda, the Cuda signing key has changed.

In looking at https://gitlab.com/nvidia/container-images/cuda/-/issues/158, the resolution is to update the Cuda Public Repo Signing Key.

Found the most recent public key here: 

https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/

and needed to update the checksum set in the DockerFile to match it up with what is expected now.

For testing, ran the CircleCI job locally to verify that this would resolve it and it did:

```
[+] Building 214.5s (14/14) FINISHED                                            
 => [internal] load build definition from Dockerfile.cuda                  0.0s
 => => transferring dockerfile: 3.04kB                                     0.0s
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 70B                                           0.0s
 => [internal] load metadata for docker.io/*****/base:develop              0.0s
 => https://api.github.com/repos/*****/puppet-*****_base/git/refs/heads/h  0.0s
 => [internal] load build context                                          0.1s
 => => transferring context: 246B                                          0.0s
 => CACHED [1/8] FROM docker.io/*****/base:develop                         0.0s
 => [2/8] ADD https://api.github.com/repos/*****/puppet-*****_base/git/re  0.1s
 => [3/8] COPY files/cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo           0.0s
 => [4/8] RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0be  0.3s
 => [5/8] RUN dnf upgrade -y && dnf install -y     cuda-cudart-11-4-11.4  33.9s
 => [6/8] RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.co  0.2s
 => [7/8] RUN dnf install -y     cuda-libraries-11-4-11.4.2-1     cuda-  164.0s
 => [8/8] WORKDIR /home/ops                                                0.0s
 => exporting to image                                                     7.7s
 => => exporting layers                                                    7.6s
 => => writing image sha256:e376b131841ec42b0ece7dc30bfdec6b0ae8b883bade7  0.0s
 => => naming to docker.io/*****/cuda-base:20220524                        0.0s
Success!

(base) MT-204713:hysds-framework mcayanan$ docker images
REPOSITORY                                                                TAG         IMAGE ID       CREATED              SIZE
hysds/cuda-base                                                           20220524    e376b131841e   About a minute ago   5.19GB
```
