### PR TITLE
hot-fix: Get the puppet release prior to attempting to install it

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ ADD https://api.github.com/repos/${ORG}/puppet-hysds_base/git/refs/heads/${BRANC
 RUN set -ex \
  && yum install -y epel-release \
  && yum update -y \
- && rpm -Uvh https://yum.puppetlabs.com/puppet5/puppet5-release-el-7.noarch.rpm \
+ && rpm -ivh https://yum.puppetlabs.com/el/7/products/x86_64/puppetlabs-release-7-11.noarch.rpm \
  && yum install -y \
     puppet puppet-firewalld wget curl git sudo \
  && curl -skL ${GIT_URL} > /tmp/install.sh \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,7 @@ ADD https://api.github.com/repos/${ORG}/puppet-hysds_base/git/refs/heads/${BRANC
 RUN set -ex \
  && yum install -y epel-release \
  && yum update -y \
+ && rpm -Uvh https://yum.puppetlabs.com/puppet5/puppet5-release-el-7.noarch.rpm \
  && yum install -y \
     puppet puppet-firewalld wget curl git sudo \
  && curl -skL ${GIT_URL} > /tmp/install.sh \


### PR DESCRIPTION
The current develop-centos7 PGE base build fails with the following error:

```
Error: Package: puppet-firewalld-0.1.3-1.el7.noarch (epel)
           Requires: puppet
```

In doing some analysis, it is found that the puppet package seems to have been removed from yum. This hot fix explicitly installs the puppet module prior to installation of the puppet-dependent packages.