### PR TITLE
hot-fix: Pin python to 3.9

### DIFF
--- a/manifests/anaconda.pp
+++ b/manifests/anaconda.pp
@@ -11,7 +11,7 @@ define hysds_base::anaconda($path='/opt/conda', $action=install_miniconda, $args
 
       exec { "download_installer":
         path    => "/usr/local/bin:/usr/bin:/bin",
-        #command => "curl -sSL https://repo.continuum.io/miniconda/Miniconda3-py39_4.10.3-Linux-x86_64.sh -o /tmp/miniconda.sh",
+        # command => "curl -sSL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh",
         # Pinning to python 3.9 until we can vett the later versions
         command => "curl -sSL https://repo.anaconda.com/miniconda/Miniconda3-py39_22.11.1-1-Linux-x86_64.sh -o /tmp/miniconda.sh",
         creates => "/tmp/miniconda.sh",

--- a/manifests/anaconda.pp
+++ b/manifests/anaconda.pp
@@ -12,7 +12,8 @@ define hysds_base::anaconda($path='/opt/conda', $action=install_miniconda, $args
       exec { "download_installer":
         path    => "/usr/local/bin:/usr/bin:/bin",
         #command => "curl -sSL https://repo.continuum.io/miniconda/Miniconda3-py39_4.10.3-Linux-x86_64.sh -o /tmp/miniconda.sh",
-        command => "curl -sSL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh",
+        # Pinning to python 3.9 until we can vett the later versions
+        command => "curl -sSL https://repo.anaconda.com/miniconda/Miniconda3-py39_22.11.1-1-Linux-x86_64.sh -o /tmp/miniconda.sh",
         creates => "/tmp/miniconda.sh",
       }
 


### PR DESCRIPTION
The move to 3.10 breaks the Core build, so pinning for now