### PR TITLE
hot-fix: pin to python3.9

### DIFF
--- a/manifests/anaconda.pp
+++ b/manifests/anaconda.pp
@@ -11,8 +11,9 @@ define hysds_base::anaconda($path='/opt/conda', $action=install_miniconda, $args
 
       exec { "download_installer":
         path    => "/usr/local/bin:/usr/bin:/bin",
-        #command => "curl -sSL https://repo.continuum.io/miniconda/Miniconda3-py39_4.10.3-Linux-x86_64.sh -o /tmp/miniconda.sh",
-        command => "curl -sSL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh",
+        # command => "curl -sSL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh",
+        # Pinning to python 3.9 until we can vett the later versions
+        command => "curl -sSL https://repo.anaconda.com/miniconda/Miniconda3-py39_22.11.1-1-Linux-x86_64.sh -o /tmp/miniconda.sh",
         creates => "/tmp/miniconda.sh",
       }
 


### PR DESCRIPTION
the latest, python3.10, breaks our build. so, pinning for now