### PR TITLE
hot-fix: remove gpg keys checking

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,9 +48,9 @@ RUN set -ex \
  #   done \
  && curl -o /usr/local/bin/gosu -SL "https://github.com/hysds/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" \
  && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/hysds/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc" \
- && gpg --verify /usr/local/bin/gosu.asc \
+ #&& gpg --verify /usr/local/bin/gosu.asc \
  && rm /usr/local/bin/gosu.asc \
- && rm -r /root/.gnupg/ \
+ #&& rm -r /root/.gnupg/ \
  && chmod +x /usr/local/bin/gosu \
  && chmod u+s /usr/local/bin/gosu \
  && curl -o /docker-stats-on-exit-shim -SL "https://github.com/hysds/docker-stats-on-exit-shim/releases/download/${DSOES_VERSION}/docker-stats-on-exit-shim" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/oraclelinux:8
+FROM oraclelinux:8
 
 MAINTAINER Gerald Manipon (pymonger) "pymonger@gmail.com"
 LABEL description "Base HySDS image"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM oraclelinux:8
+FROM arm64v8/oraclelinux:8
 
 MAINTAINER Gerald Manipon (pymonger) "pymonger@gmail.com"
 LABEL description "Base HySDS image"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,14 +36,16 @@ RUN set -ex \
  && dnf clean all \
  && rm -f /tmp/install.sh \
  && rm -rf /var/cache/dnf \
- && for server in ha.pool.sks-keyservers.net \
-      hkp://p80.pool.sks-keyservers.net:80 \
-      keyserver.ubuntu.com \
-      hkp://keyserver.ubuntu.com:80 \
-      keyserver.pgp.com \
-      pgp.mit.edu; do \
-      gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
-    done \
+ # Commenting out for now as we are consistently getting
+ # the following error: gpg: keyserver receive failed: Server indicated a failure
+ # && for server in ha.pool.sks-keyservers.net \
+ #     hkp://p80.pool.sks-keyservers.net:80 \
+ #     keyserver.ubuntu.com \
+ #     hkp://keyserver.ubuntu.com:80 \
+ #     keyserver.pgp.com \
+ #     pgp.mit.edu; do \
+ #     gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
+ #   done \
  && curl -o /usr/local/bin/gosu -SL "https://github.com/hysds/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" \
  && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/hysds/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc" \
  && gpg --verify /usr/local/bin/gosu.asc \


### PR DESCRIPTION
Circleci is continually failing due to the following error:

![image](https://user-images.githubusercontent.com/42812746/229158530-105adbdf-d941-47f4-bc51-4ffaa135124b.png)

The recommendation is to remove the gpg command line calls as they are not needed.