### PR TITLE
HC-557: Remove /var/lib/containers/sigstore from base

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -60,7 +60,6 @@ RUN set -ex \
  #&& gpg --verify /usr/local/bin/gosu.asc \
  && rm /usr/local/bin/gosu.asc \
  #&& rm -r /root/.gnupg/ \
- && rm -rf /var/lib/containers \
  && chmod +x /usr/local/bin/gosu \
  && chmod u+s /usr/local/bin/gosu \
  && curl -o /docker-stats-on-exit-shim -SL "https://github.com/hysds/docker-stats-on-exit-shim/releases/download/${DSOES_VERSION}/docker-stats-on-exit-shim" \
@@ -71,8 +70,10 @@ RUN set -ex \
 
 # Note VOLUME options must always happen after the chown call above
 # RUN commands can not modify existing volumes
-VOLUME /var/lib/containers
+#VOLUME /var/lib/containers
 VOLUME /root/.local/share/containers
+
+
 
 # set default user and workdir
 USER $USER

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,9 +70,11 @@ RUN set -ex \
 
 # Note VOLUME options must always happen after the chown call above
 # RUN commands can not modify existing volumes
-#VOLUME /var/lib/containers
+VOLUME /var/lib/containers
 VOLUME /root/.local/share/containers
 
+# Remove this directory as it contains extended attributes
+RUN rm -rf /var/lib/containers/sigstore
 
 
 # set default user and workdir

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -60,6 +60,7 @@ RUN set -ex \
  #&& gpg --verify /usr/local/bin/gosu.asc \
  && rm /usr/local/bin/gosu.asc \
  #&& rm -r /root/.gnupg/ \
+ && rm -rf /var/lib/containers \
  && chmod +x /usr/local/bin/gosu \
  && chmod u+s /usr/local/bin/gosu \
  && curl -o /docker-stats-on-exit-shim -SL "https://github.com/hysds/docker-stats-on-exit-shim/releases/download/${DSOES_VERSION}/docker-stats-on-exit-shim" \


### PR DESCRIPTION
This PR updates the docker build file to remove the `/var/lib/containers/sigstore` directory as it contains extended attributes that break running the container on HECC roam nodes


As a test, successfully re-built the containers with this directory removed:

![image](https://github.com/user-attachments/assets/8ac052f5-f8fb-4467-8fda-c3a39c5a6b00)

bash'd into the Verdi container and verified that the `sigstore` dir no longer exists:

![image](https://github.com/user-attachments/assets/cd2668be-c172-42ea-953f-46e15821f817)


Also verified that it does not exist in the pge-base layer where PCM containers inherit from:

![image](https://github.com/user-attachments/assets/af4cb625-581f-41e3-b0e0-3c0a32cd6787)
