### PR TITLE
HC-616: Added cgroup v2 support with Backwards Compatiblity

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ LABEL description "Base HySDS image"
 ENV GOSU_VERSION 1.10
 
 # Set docker-stats-on-exit-shim version
-ENV DSOES_VERSION v1.0
+ENV DSOES_VERSION v2.0
 
 # Set user and group
 ENV USER root


### PR DESCRIPTION
This PR is dependent on https://github.com/hysds/docker-stats-on-exit-shim/pull/1

The update here updates the dockerfile such that we build a container with an updated version of the docker-stats-on-exit-shim binary that supports cgroups v2, while being backwards compatible with cgroups v1.

See https://github.com/hysds/docker-stats-on-exit-shim/pull/1 for testing verification